### PR TITLE
Fix CSS typos

### DIFF
--- a/estilo.css
+++ b/estilo.css
@@ -37,7 +37,6 @@ html{
     list-style: none;
 }
 .contenedor-header header nav ul li a{
-    text-align: none;
     color: #fff;
     margin: 0 15px;
     padding: 3px;
@@ -590,7 +589,7 @@ html{
     top: 40%;
     background-color: #252A2E;
     padding: 20px;
-    max-swidth: 350px;
+    max-width: 350px;
     left: 50%;
     transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
## Summary
- fix invalid `text-align` rule in menu links
- correct `max-swidth` typo to `max-width`

## Testing
- `npx --yes htmlhint index.html estilo.css script.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846df8df77483288800d372315c5ef0